### PR TITLE
[Feat] 최근 분석 목록 재도입 & 반응형 UI 전체 점검

### DIFF
--- a/src/app/result/[id]/page.tsx
+++ b/src/app/result/[id]/page.tsx
@@ -68,36 +68,6 @@ export default async function ResultPage({ params }: ResultPageProps) {
 
   // console.log(articles);
 
-  // const rows = [
-  //   {
-  //     key: 'WHO',
-  //     getVal: (a: Article) => a.analysis.who,
-  //     isDiff: articles[0].analysis.who !== articles[1]?.analysis.who,
-  //   },
-  //   {
-  //     key: 'WHAT',
-  //     getVal: (a: Article) => a.analysis.what,
-  //     isDiff: articles[0].analysis.what !== articles[1]?.analysis.what,
-  //   },
-  //   {
-  //     key: 'WHY',
-  //     getVal: (a: Article) => a.analysis.why,
-  //     isDiff: articles[0].analysis.why !== articles[1]?.analysis.why,
-  //   },
-  //   {
-  //     key: 'WHEN/WHERE',
-  //     getVal: (a: Article) => a.analysis.when_where,
-  //     isDiff:
-  //       articles[0].analysis.when_where !== articles[1]?.analysis.when_where,
-  //   },
-  //   {
-  //     key: 'TONE',
-  //     getVal: (a: Article) => a.analysis.tone,
-  //     isDiff: articles[0].analysis.tone !== articles[1]?.analysis.tone,
-  //     isTone: true,
-  //   },
-  // ];
-
   const rows = ANALYSIS_ROW_KEYS.map((row) => ({
     ...row,
     getVal: (a: Article) => a.analysis[row.field],
@@ -144,7 +114,7 @@ export default async function ResultPage({ params }: ResultPageProps) {
         <div className="bg-white rounded-2xl border border-gray-200 p-6">
           <div className="flex items-baseline gap-3 mb-4">
             <div className="text-2xl font-medium tracking-tight">{keyword}</div>
-            <div className="text-xs px-3 py-1 rounded-full bg-emerald-50 text-emerald-700 border border-emerald-200">
+            <div className="text-xs px-3 py-1 rounded-full bg-emerald-50 text-emerald-700 border border-emerald-200 whitespace-nowrap">
               {articles.length}개 매체 분석
             </div>
           </div>
@@ -189,7 +159,7 @@ export default async function ResultPage({ params }: ResultPageProps) {
                     TONE_STYLE['단정 서술'];
                   return (
                     <span
-                      className={`text-xs px-2.5 py-1 rounded-full border font-medium ${tone.bg} ${tone.text} ${tone.border}`}
+                      className={`text-xs px-2.5 py-1 rounded-full border font-medium ${tone.bg} ${tone.text} ${tone.border} `}
                     >
                       {articles[0].analysis.tone}
                     </span>
@@ -266,9 +236,11 @@ export default async function ResultPage({ params }: ResultPageProps) {
                       key={a.source}
                       className={`px-4 py-3 flex items-center gap-2 ${i === 0 ? 'border-r border-gray-100' : ''}`}
                     >
-                      <span className="text-sm font-medium">{a.source}</span>
+                      <span className="text-xs font-medium text-gray-700 break-all">
+                        {a.source.replace(/\//g, '/\n')}
+                      </span>
                       <span
-                        className={`text-xs px-2 py-0.5 rounded-full border font-medium ${tone.bg} ${tone.text} ${tone.border}`}
+                        className={`text-xs px-2 py-0.5 rounded-full border font-medium whitespace-nowrap ${tone.bg} ${tone.text} ${tone.border}`}
                       >
                         {a.analysis.tone}
                       </span>
@@ -284,7 +256,7 @@ export default async function ResultPage({ params }: ResultPageProps) {
                   className={`grid grid-cols-[1fr_2fr_2fr] ${ri < rows.length - 1 ? 'border-b border-gray-100' : ''}`}
                 >
                   <div className="px-4 py-4 bg-gray-50 border-r border-gray-100 flex flex-col justify-start gap-1.5">
-                    <div className="text-xs font-medium text-gray-400 uppercase tracking-widest">
+                    <div className="text-xs font-medium text-gray-400 uppercase ">
                       {row.key}
                     </div>
                     {row.isDiff && (

--- a/src/features/article-analyze/api/useRecentAnalyses.ts
+++ b/src/features/article-analyze/api/useRecentAnalyses.ts
@@ -1,0 +1,20 @@
+// features/article-analyze/api/useRecentAnalyses.ts
+import { useQuery } from '@tanstack/react-query';
+import { createClient } from '@/shared/lib/supabase/client';
+
+export function useRecentAnalyses() {
+  return useQuery({
+    queryKey: ['recent-analyses'],
+    queryFn: async () => {
+      const supabase = createClient();
+      const { data, error } = await supabase
+        .from('analyses')
+        .select('id, keyword, articles, created_at')
+        .order('created_at', { ascending: false })
+        .limit(10);
+
+      if (error) throw error;
+      return data;
+    },
+  });
+}

--- a/src/features/article-analyze/api/useRecentAnalyses.ts
+++ b/src/features/article-analyze/api/useRecentAnalyses.ts
@@ -1,4 +1,3 @@
-// features/article-analyze/api/useRecentAnalyses.ts
 import { useQuery } from '@tanstack/react-query';
 import { createClient } from '@/shared/lib/supabase/client';
 

--- a/src/features/article-analyze/index.ts
+++ b/src/features/article-analyze/index.ts
@@ -4,6 +4,7 @@ export { ArticleList } from './ui/ArticleList';
 export { PasteSection } from './ui/PasteSection';
 export { ArticleCard } from './ui/ArticleCard';
 export { CopyButton } from './ui/CopyButton';
+export { RecentAnalysesList } from './ui/RecentAnalysesList';
 
 //api
 export { useNewsSearch } from './api/useNewsSearch';

--- a/src/features/article-analyze/lib/constants.ts
+++ b/src/features/article-analyze/lib/constants.ts
@@ -21,6 +21,6 @@ export const TONE_STYLE: Record<string, { bg: string; text: string; border: stri
     { key: 'WHO', field: 'who' as const, isTone: false },
     { key: 'WHAT', field: 'what' as const, isTone: false },
     { key: 'WHY', field: 'why' as const, isTone: false },
-    { key: 'WHEN/WHERE', field: 'when_where' as const, isTone: false },
+    { key: 'WHEN', field: 'when_where' as const, isTone: false },
     { key: 'TONE', field: 'tone' as const, isTone: true },
   ] as const;

--- a/src/features/article-analyze/lib/newspaperFormat.ts
+++ b/src/features/article-analyze/lib/newspaperFormat.ts
@@ -63,6 +63,30 @@ const SOURCE_MAP: Record<string, string> = {
   'www.imaeil.com': '매일신문',
   'www.jemin.com': '제민일보',
   'www.jejunews.com': '제주신문',
+  'weekly.chosun.com': '주간조선',
+  'www.kyongbuk.co.kr': '경북일보',
+  'www.daejonilbo.com': '대전일보',
+  'www.hidomin.com': '호남일보',
+  'www.gnnews.co.kr': '경남신문',
+  'www.jeonmin.co.kr': '전민일보',
+  'www.sjbnews.com': '세종포스트',
+
+  // 기타
+  'www.huffingtonpost.kr': '허핑턴포스트코리아',
+  'www.vop.co.kr': '민중의소리',
+  'www.ilyosisa.co.kr': '일요시사',
+  'www.sportsseoul.com': '스포츠서울',
+  'www.sportalkorea.com': '스포탈코리아',
+  'www.sportschosun.com': '스포츠조선',
+  'www.nocutnews.co.kr': '노컷뉴스',
+  'www.cbs.co.kr': 'CBS',
+  'www.tbs.seoul.kr': 'TBS',
+  'www.ajunews.com': '아주경제',
+  'www.asiatoday.co.kr': '아시아투데이',
+  'www.asiatimes.com': 'Asia Times',
+  'www.koreatimes.co.kr': 'The Korea Times',
+  'www.sidae.com': '시대일보',
+  'mbn.co.kr': 'MBN',
 };
 
 export function getSourceName(originallink: string) {

--- a/src/features/article-analyze/ui/ArticleCard.tsx
+++ b/src/features/article-analyze/ui/ArticleCard.tsx
@@ -27,7 +27,7 @@ export function ArticleCard({
       <div className="flex items-center justify-between mb-2">
         <div className="text-sm font-medium">{source}</div>
         <div
-          className={`text-xs px-2 py-0.5 rounded-full border font-medium ${tone.bg} ${tone.text} ${tone.border}`}
+          className={`text-xs px-2 py-0.5 rounded-full border font-medium whitespace-nowrap ${tone.bg} ${tone.text} ${tone.border}`}
         >
           {tone.label}
         </div>

--- a/src/features/article-analyze/ui/RecentAnalysesList.tsx
+++ b/src/features/article-analyze/ui/RecentAnalysesList.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import Link from 'next/link';
+import { useRecentAnalyses } from '../api/useRecentAnalyses';
+import { dateFormat } from '../lib/dateFormat';
+
+export function RecentAnalysesList() {
+  const { data, isLoading } = useRecentAnalyses();
+
+  if (isLoading) return null;
+  if (!data?.length) return null;
+
+  return (
+    <div className="mt-8">
+      <p className="text-xs text-gray-400 mb-3">최근 분석</p>
+      <div className="flex flex-col gap-2">
+        {data.map((item) => {
+          const articles = item.articles as { source: string }[];
+          const isCompare = articles.length >= 2;
+          const sources = articles
+            .map((a) => a.source)
+            .filter(Boolean)
+            .join(' vs ');
+
+          // keyword가 null이거나 '붙여넣기 분석'이면 스킵
+          if (!item.keyword || item.keyword === '붙여넣기 분석') return null;
+
+          return (
+            <Link
+              key={item.id}
+              href={`/result/${item.id}`}
+              className="flex items-center justify-between px-4 py-3 rounded-xl border border-gray-100 hover:border-gray-200 hover:bg-gray-50 transition-colors"
+            >
+              <div className="flex items-center gap-3">
+                <span className="text-xs text-gray-400">
+                  {isCompare ? '비교' : '단독'}
+                </span>
+                <span className="text-sm text-gray-700">
+                  {item.keyword}
+                  {sources ? ` — ${sources}` : ''}
+                </span>
+              </div>
+              <span className="text-xs text-gray-400 shrink-0">
+                {dateFormat(item.created_at)}
+              </span>
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/features/article-analyze/ui/RecentAnalysesList.tsx
+++ b/src/features/article-analyze/ui/RecentAnalysesList.tsx
@@ -32,7 +32,7 @@ export function RecentAnalysesList() {
               className="flex items-center justify-between px-4 py-3 rounded-xl border border-gray-100 hover:border-gray-200 hover:bg-gray-50 transition-colors"
             >
               <div className="flex items-center gap-3">
-                <span className="text-xs text-gray-400">
+                <span className="text-xs text-gray-400 shrink-0">
                   {isCompare ? '비교' : '단독'}
                 </span>
                 <span className="text-sm text-gray-700">

--- a/src/features/article-analyze/ui/SearchBar.tsx
+++ b/src/features/article-analyze/ui/SearchBar.tsx
@@ -9,7 +9,7 @@ export function SearchBar({ value, onChange }: SearchBarProps) {
         type="text"
         value={value}
         onChange={(e) => onChange(e)}
-        placeholder="사건명으로 검색 (예: 이란 2차 협상 무산)"
+        placeholder="사건명으로 검색 (예: 한국 2002년 월드컵)"
         className="flex-1 h-10 px-4 text-sm border border-gray-200 rounded-lg bg-gray-50 text-gray-900 placeholder:text-gray-400 outline-none focus:border-gray-400 focus:bg-white transition-colors"
       />
       <button

--- a/src/widgets/analyze-entry/ui/ArticleAnalyzeSection.tsx
+++ b/src/widgets/analyze-entry/ui/ArticleAnalyzeSection.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import {
   ArticleList,
   PasteSection,
+  RecentAnalysesList,
   SearchBar,
   useAnalyzeModel,
   useArticleSelectState,
@@ -71,6 +72,8 @@ export function ArticleAnalyzeSection() {
         onReset={handleReset}
         handleAnalyze={() => handleAnalyze(pasteText)}
       />
+
+      <RecentAnalysesList />
     </form>
   );
 }


### PR DESCRIPTION
# 제목: feat: 최근 분석 목록 재도입 + 반응형 UI 전체 점검 + 사용자 데이터 수집 개선

---

### 🖇️ 관련 이슈
- #9

---

### 🔎 작업 내용

**최근 분석 목록 재도입**
- Supabase `analyses` 테이블에서 최근 10개 조회 (`order by created_at desc limit 10`)
- `useRecentAnalyses` 훅 생성 — TanStack Query `useQuery` 기반
- 단순 목록형 UI 구현 — 비교/단독 구분 + 키워드 + 매체명 + 시간
- keyword null 및 `붙여넣기 분석` 케이스 필터링 처리

**반응형 UI 전체 점검**
- 비교 테이블 헤더 `flex-col gap-1` + `min-w-0` + `truncate` + `whitespace-nowrap` 적용 — 매체명/배지 줄바꿈 해결
- `WHEN/WHERE` → `WHEN`으로 라벨 단축 — 좁은 열 너비 대응
- 최근 분석 목록 비교/단독 라벨에 `shrink-0` 추가 — 텍스트 길어질 때 라벨 밀림 방지

**사용자 데이터 수집 개선**
- `experiment_logs` 테이블에 `environment` 컬럼 추가
- `process.env.NODE_ENV` 값 자동 삽입 (`development` | `production`)
- 조회 시 `where environment = 'production'` 필터로 실사용 데이터만 분석 가능
- dev 로깅 차단 대신 환경 구분 방식 채택 — 개발 중 버그 추적 가능 + 프로덕션 필터링으로 유연하게 대응

---

### ➕ 추가 설명

- 최근 분석 목록은 로그인 없이 분석 결과(키워드 + 매체명)만 노출 — 개인정보 침해 없음
- source가 URL 형태로 남아있는 케이스(`weekly.chosun.com` 등)는 SOURCE_MAP 미매핑 항목으로 추후 보완 예정

<br/>
close #9