### PR TITLE
[Feat] 에러 핸들링 고도화 & 로그 고도화 (kakao_share, original_link_click 이벤트 추가)

### DIFF
--- a/src/app/result/[id]/page.tsx
+++ b/src/app/result/[id]/page.tsx
@@ -3,6 +3,7 @@ import {
   Article,
   ArticleCard,
   CopyButton,
+  OriginalLinkButton,
   ResultPageProps,
   TONE_STYLE,
 } from '@/features/article-analyze';
@@ -10,7 +11,7 @@ import { createClient } from '@/shared/lib/supabase/server';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
-import { KakaoShareButton } from '@/shared';
+import { KakaoShareButton, Toast } from '@/shared';
 
 export async function generateMetadata({
   params,
@@ -349,23 +350,33 @@ export default async function ResultPage({ params }: ResultPageProps) {
               </div>
             </div>
 
-            {/* ── 비교 원문 링크 (기존 유지) ── */}
-            <div className="grid grid-cols-2 gap-3">
-              {articles.map((a) => (
-                <a
-                  key={a.source}
-                  href={a.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center justify-center gap-2 py-3 rounded-xl border border-gray-200 bg-white text-xs text-gray-400 hover:bg-gray-50 transition-colors"
-                >
-                  {a.source} 원문 보기 →
-                </a>
-              ))}
-            </div>
+              {/* ── 비교 원문 링크 (기존 유지) ── */}
+              {/* <div className="grid grid-cols-2 gap-3">
+                {articles.map((a) => (
+                  <a
+                    key={a.source}
+                    href={a.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={() =>
+                      log({
+                        query,
+                        eventType: 'original_link_click',
+                        articleLink: article.link,
+                      })
+                    }
+                    className="flex items-center justify-center gap-2 py-3 rounded-xl border border-gray-200 bg-white text-xs text-gray-400 hover:bg-gray-50 transition-colors"
+                  >
+                    {a.source} 원문 보기 →
+                  </a>
+                ))}
+              </div> */}
+              <OriginalLinkButton articles={articles} />
           </>
         )}
       </div>
+
+      <Toast />
     </div>
   );
 }

--- a/src/features/article-analyze/api/useAnalyze.ts
+++ b/src/features/article-analyze/api/useAnalyze.ts
@@ -3,13 +3,11 @@ import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import axios from 'axios';
 import { AnalyzeParams } from '../model/type';
+import { useToastMessageStore } from '../model/useToastMessageStore';
 
-export function useAnalyze({
-  setToastMessage,
-}: {
-  setToastMessage: (message: string) => void;
-}) {
+export function useAnalyze() {
   const router = useRouter();
+  const { setToastMessage } = useToastMessageStore();
 
   return useMutation({
     mutationFn: async (params: AnalyzeParams) => {

--- a/src/features/article-analyze/api/useAnalyze.ts
+++ b/src/features/article-analyze/api/useAnalyze.ts
@@ -1,11 +1,14 @@
-'use client'
+'use client';
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import axios from 'axios';
 import { AnalyzeParams } from '../model/type';
 
-
-export function useAnalyze() {
+export function useAnalyze({
+  setToastMessage,
+}: {
+  setToastMessage: (message: string) => void;
+}) {
   const router = useRouter();
 
   return useMutation({
@@ -15,10 +18,12 @@ export function useAnalyze() {
     },
     onSuccess: ({ id }) => {
       router.push(`/result/${String(id)}`);
-      
     },
     onError: (error) => {
-      console.error('분석 실패:', error);
+      if (axios.isAxiosError(error)) {
+        console.log('Axios error:', error.response?.data || error.message);
+        setToastMessage('분석 중 오류가 발생했습니다. 다시 시도해주세요.');
+      }
     },
   });
 }

--- a/src/features/article-analyze/api/useCluster.ts
+++ b/src/features/article-analyze/api/useCluster.ts
@@ -1,8 +1,11 @@
 import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
 import { NaverArticle, ClusterResult } from '../model/type';
+import { useToastMessageStore } from '../model/useToastMessageStore';
 
 export function useCluster() {
+  const { setToastMessage } = useToastMessageStore();
+
   return useMutation<ClusterResult, Error, NaverArticle[]>({
     mutationFn: async (items: NaverArticle[]) => {
       const { data } = await axios.post('/api/cluster', { items });
@@ -10,6 +13,9 @@ export function useCluster() {
     },
     onError: (error) => {
       console.error('클러스터링 중 오류 발생:', error);
+      if(axios.isAxiosError(error)) {
+        setToastMessage('클러스터링 중 오류가 발생했습니다.');
+      }
     },
   });
 }

--- a/src/features/article-analyze/api/useExperimentLog.ts
+++ b/src/features/article-analyze/api/useExperimentLog.ts
@@ -8,8 +8,8 @@ export function useExperimentLog() {
     eventType,
     articleLink,
   }: {
-    mode: Mode;
-    query: string;
+    mode?: Mode;
+    query?: string;
     eventType: EventType;
     articleLink?: string;
   }) => {
@@ -20,6 +20,7 @@ export function useExperimentLog() {
       query,
       event_type: eventType,
       article_link: articleLink ?? null,
+      environment: process.env.NODE_ENV,
     });
   };
 

--- a/src/features/article-analyze/api/useExperimentLog.ts
+++ b/src/features/article-analyze/api/useExperimentLog.ts
@@ -1,8 +1,5 @@
-
 import { createClient } from '@/shared/lib/supabase/client';
-
-type Mode = 'flat' | 'cluster';
-type EventType = 'deselect' | 'compare_start';
+import { EventType, Mode } from '../model/type';
 
 export function useExperimentLog() {
   const log = async ({

--- a/src/features/article-analyze/api/useNewsSearch.ts
+++ b/src/features/article-analyze/api/useNewsSearch.ts
@@ -1,10 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
-import { NewsResultProps } from '../model/type';
-
-interface UseNewsSearchOptions {
-  onSuccess?: (data: NewsResultProps) => void;
-}
+import { NewsResultProps, UseNewsSearchOptions } from '../model/type';
 
 export function useNewsSearch(options?: UseNewsSearchOptions) {
   return useMutation<NewsResultProps, Error, string>({

--- a/src/features/article-analyze/api/useNewsSearch.ts
+++ b/src/features/article-analyze/api/useNewsSearch.ts
@@ -1,8 +1,11 @@
 import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
 import { NewsResultProps, UseNewsSearchOptions } from '../model/type';
+import { useToastMessageStore } from '../model/useToastMessageStore';
 
 export function useNewsSearch(options?: UseNewsSearchOptions) {
+  const { setToastMessage } = useToastMessageStore();
+
   return useMutation<NewsResultProps, Error, string>({
     mutationFn: async (query: string) => {
       const { data } = await axios.get('/api/search', {
@@ -14,9 +17,15 @@ export function useNewsSearch(options?: UseNewsSearchOptions) {
     },
     onSuccess: (data) => {
       options?.onSuccess?.(data);
+      if(!data.items || data.items.length === 0) {
+        setToastMessage('검색 결과가 없습니다.');
+      }
     },
     onError: (error) => {
       console.error('뉴스 검색 중 오류 발생:', error);
+      if (axios.isAxiosError(error)) {
+        setToastMessage('뉴스 검색 중 오류가 발생했습니다.');
+      }
     },
   });
 }

--- a/src/features/article-analyze/index.ts
+++ b/src/features/article-analyze/index.ts
@@ -6,6 +6,7 @@ export { ArticleCard } from './ui/ArticleCard';
 export { CopyButton } from './ui/CopyButton';
 export { RecentAnalysesList } from './ui/RecentAnalysesList';
 export { ToggleButton } from './ui/ToggleButton';
+export {OriginalLinkButton} from './ui/OriginalLinkButton';
 
 //api
 export { useNewsSearch } from './api/useNewsSearch';
@@ -19,6 +20,7 @@ export { useAnalyzeModel } from './model/useAnalyzeModel';
 export { useSelectedNewsStore } from './model/useSelectedNewsStore';
 export type { Article, ResultPageProps } from './model/type';
 export { useToastMessageStore } from './model/useToastMessageStore';
+export { useExperimentLog } from './api/useExperimentLog';
 
 //lib
 export { getSourceName } from './lib/newspaperFormat';

--- a/src/features/article-analyze/index.ts
+++ b/src/features/article-analyze/index.ts
@@ -5,6 +5,7 @@ export { PasteSection } from './ui/PasteSection';
 export { ArticleCard } from './ui/ArticleCard';
 export { CopyButton } from './ui/CopyButton';
 export { RecentAnalysesList } from './ui/RecentAnalysesList';
+export { ToggleButton } from './ui/ToggleButton';
 
 //api
 export { useNewsSearch } from './api/useNewsSearch';
@@ -15,8 +16,9 @@ export type { NewsResultProps, NewsItem } from './model/type';
 export { useArticleSelectState } from './model/useArticleSelectState';
 export { useSearchModel } from './model/useSearchModel';
 export { useAnalyzeModel } from './model/useAnalyzeModel';
-export { useSelectedNewsStore} from "./model/useSelectedNewsStore"
+export { useSelectedNewsStore } from './model/useSelectedNewsStore';
 export type { Article, ResultPageProps } from './model/type';
+export { useToastMessageStore } from './model/useToastMessageStore';
 
 //lib
 export { getSourceName } from './lib/newspaperFormat';

--- a/src/features/article-analyze/model/type.ts
+++ b/src/features/article-analyze/model/type.ts
@@ -85,3 +85,10 @@ export interface Article {
 export interface ResultPageProps {
   params: Promise<{ id: string }>;
 }
+
+export interface UseNewsSearchOptions {
+  onSuccess?: (data: NewsResultProps) => void;
+}
+
+export type Mode = 'flat' | 'cluster';
+export type EventType = 'deselect' | 'compare_start';

--- a/src/features/article-analyze/model/type.ts
+++ b/src/features/article-analyze/model/type.ts
@@ -12,6 +12,7 @@ export interface ArticleListProps {
   canCompare: boolean;
   handleCompare: () => void;
   isPending: boolean;
+  isAnalyzeError: boolean;
 }
 
 export interface PasteSectionProps {

--- a/src/features/article-analyze/model/type.ts
+++ b/src/features/article-analyze/model/type.ts
@@ -91,4 +91,4 @@ export interface UseNewsSearchOptions {
 }
 
 export type Mode = 'flat' | 'cluster';
-export type EventType = 'deselect' | 'compare_start';
+export type EventType = 'deselect' | 'compare_start' | 'kakao_share' | 'original_link_click';

--- a/src/features/article-analyze/model/useAnalyzeModel.ts
+++ b/src/features/article-analyze/model/useAnalyzeModel.ts
@@ -10,7 +10,7 @@ export function useAnalyzeModel(mode: SearchMode, query: string) {
   const { log } = useExperimentLog();
 
   const handleCompare = (selected: NewsItem[], keyword: string) => {
-    log({ mode, query, eventType: 'compare_start' }); // 추가
+    log({ mode, query, eventType: 'compare_start' }); // 비교 시작 로그
     analyze({
       keyword,
       articles: selected.map((article) => ({

--- a/src/features/article-analyze/model/useAnalyzeModel.ts
+++ b/src/features/article-analyze/model/useAnalyzeModel.ts
@@ -1,5 +1,4 @@
 'use client';
-import { useState } from 'react';
 import { useAnalyze } from '../api/useAnalyze';
 import { useExperimentLog } from '../api/useExperimentLog';
 import { getSourceName } from '../lib/newspaperFormat';
@@ -7,8 +6,7 @@ import { stripHtml } from '../lib/striphtml';
 import type { NewsItem, SearchMode } from './type';
 
 export function useAnalyzeModel(mode: SearchMode, query: string) {
-  const [toastMessage, setToastMessage] = useState('');
-  const { mutate: analyze, isPending,isError: isAnalyzeError } = useAnalyze({ setToastMessage });
+  const { mutate: analyze, isPending, isError: isAnalyzeError } = useAnalyze();
   const { log } = useExperimentLog();
 
   const handleCompare = (selected: NewsItem[], keyword: string) => {
@@ -36,7 +34,5 @@ export function useAnalyzeModel(mode: SearchMode, query: string) {
     handleAnalyze,
     isPending,
     isAnalyzeError,
-    toastMessage,
-    clearToast: () => setToastMessage(''),
   };
 }

--- a/src/features/article-analyze/model/useAnalyzeModel.ts
+++ b/src/features/article-analyze/model/useAnalyzeModel.ts
@@ -1,12 +1,14 @@
+'use client';
+import { useState } from 'react';
 import { useAnalyze } from '../api/useAnalyze';
 import { useExperimentLog } from '../api/useExperimentLog';
 import { getSourceName } from '../lib/newspaperFormat';
 import { stripHtml } from '../lib/striphtml';
 import type { NewsItem, SearchMode } from './type';
 
-export function useAnalyzeModel(mode: SearchMode,
-  query: string,) {
-  const { mutate: analyze, isPending } = useAnalyze();
+export function useAnalyzeModel(mode: SearchMode, query: string) {
+  const [toastMessage, setToastMessage] = useState('');
+  const { mutate: analyze, isPending,isError: isAnalyzeError } = useAnalyze({ setToastMessage });
   const { log } = useExperimentLog();
 
   const handleCompare = (selected: NewsItem[], keyword: string) => {
@@ -24,7 +26,7 @@ export function useAnalyzeModel(mode: SearchMode,
 
   const handleAnalyze = (pasteText: string) => {
     analyze({
-      keyword: "붙여넣기 분석",
+      keyword: '붙여넣기 분석',
       articles: [{ title: '', content: pasteText }],
     });
   };
@@ -33,5 +35,8 @@ export function useAnalyzeModel(mode: SearchMode,
     handleCompare,
     handleAnalyze,
     isPending,
+    isAnalyzeError,
+    toastMessage,
+    clearToast: () => setToastMessage(''),
   };
 }

--- a/src/features/article-analyze/model/useSearchModel.ts
+++ b/src/features/article-analyze/model/useSearchModel.ts
@@ -20,7 +20,6 @@ export function useSearchModel() {
     mutate: searchNews,
     data: searchData,
     isPending: isSearching,
-    isError: isSearchError,
   } = useNewsSearch({
     onSuccess: (data) => {
       if (mode === 'cluster') {
@@ -44,21 +43,12 @@ export function useSearchModel() {
     ? { groups: [{ topic: '검색 결과', articles: searchData.items }] }
     : undefined;
 
-    // const isErrors = true;
-    // const isLoadings = false;
-    // const isSuccesses = true;
-
-
   return {
     mode,
     toggleMode,
     handleSearch,
     searchData: mode === 'cluster' ? clusterData : flatAsCluster,
     isSuccess: mode === 'cluster' ? !!clusterData : !!flatAsCluster,
-    // isSuccess: isSuccesses,
     isLoading: isSearching || (mode === 'cluster' && isClustering),
-    // isLoading: isLoadings,
-    isSearchError,
-    // isSearchError: isErrors,
   };
 }

--- a/src/features/article-analyze/model/useSearchModel.ts
+++ b/src/features/article-analyze/model/useSearchModel.ts
@@ -20,6 +20,7 @@ export function useSearchModel() {
     mutate: searchNews,
     data: searchData,
     isPending: isSearching,
+    isError: isSearchError,
   } = useNewsSearch({
     onSuccess: (data) => {
       if (mode === 'cluster') {
@@ -43,12 +44,21 @@ export function useSearchModel() {
     ? { groups: [{ topic: '검색 결과', articles: searchData.items }] }
     : undefined;
 
+    // const isErrors = true;
+    // const isLoadings = false;
+    // const isSuccesses = true;
+
+
   return {
     mode,
     toggleMode,
     handleSearch,
     searchData: mode === 'cluster' ? clusterData : flatAsCluster,
-    isSuccess: mode === 'cluster' ? !!clusterData : !!flatAsCluster, // 각 모드 기준으로
+    isSuccess: mode === 'cluster' ? !!clusterData : !!flatAsCluster,
+    // isSuccess: isSuccesses,
     isLoading: isSearching || (mode === 'cluster' && isClustering),
+    // isLoading: isLoadings,
+    isSearchError,
+    // isSearchError: isErrors,
   };
 }

--- a/src/features/article-analyze/model/useToastMessageStore.ts
+++ b/src/features/article-analyze/model/useToastMessageStore.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand';
+
+interface ToastMessageState {
+  message: string;
+  show: boolean;
+  setToastMessage: (message: string) => void;
+  clearToastMessage: () => void;
+}
+
+export const useToastMessageStore = create<ToastMessageState>((set) => ({
+  message: '',
+  show: false,
+  setToastMessage: (message) => {
+    set({ message, show: true });
+    setTimeout(() => set({ show: false }), 3000); // 3초 후에 자동으로 사라지도록
+  },
+  clearToastMessage: () => set({ message: '', show: false }),
+}));

--- a/src/features/article-analyze/ui/ArticleList.tsx
+++ b/src/features/article-analyze/ui/ArticleList.tsx
@@ -13,6 +13,7 @@ export function ArticleList({
   canCompare,
   handleCompare,
   isPending,
+  isAnalyzeError
 }: ArticleListProps) {
   return (
     <div className="flex flex-col gap-4 mb-7">
@@ -82,6 +83,12 @@ export function ArticleList({
         >
           {isPending ? '분석 중...' : `${selected.length}개 기사 비교 분석 →`}
         </Button>
+
+        {isAnalyzeError && (
+          <p className="text-xs text-red-400 text-center mt-2">
+            분석 중 오류가 발생했습니다. 다시 시도해주세요.
+          </p>
+        )}
       </div>
     </div>
   );

--- a/src/features/article-analyze/ui/OriginalLinkButton.tsx
+++ b/src/features/article-analyze/ui/OriginalLinkButton.tsx
@@ -1,0 +1,29 @@
+'use client';
+import { useExperimentLog } from '../api/useExperimentLog';
+import { Article } from '../model/type';
+
+export function OriginalLinkButton({ articles }: { articles: Article[] }) {
+  const { log } = useExperimentLog();
+
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      {articles.map((a) => (
+        <a
+          key={a.source}
+          href={a.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() =>
+            log({
+              eventType: 'original_link_click',
+              articleLink: a.url,
+            })
+          }
+          className="flex items-center justify-center gap-2 py-3 rounded-xl border border-gray-200 bg-white text-xs text-gray-400 hover:bg-gray-50 transition-colors"
+        >
+          {a.source} 원문 보기 →
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/src/features/article-analyze/ui/ToggleButton.tsx
+++ b/src/features/article-analyze/ui/ToggleButton.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export function ToggleButton({
+  mode,
+  toggleMode,
+}: {
+  mode: string;
+  toggleMode: () => void;
+}) {
+  return (
+    <div className="flex justify-end mb-2">
+      <button
+        type="button"
+        onClick={toggleMode}
+        className="text-xs px-3 py-1.5 rounded-lg border border-gray-200 text-gray-400 hover:border-gray-300 hover:text-gray-600 transition-colors"
+      >
+        {mode === 'cluster' ? '📋 목록 보기' : '🗂 그룹 보기'}
+      </button>
+    </div>
+  );
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -7,5 +7,6 @@ export { Textarea } from './ui/textarea';
 export { Button } from './ui/button';
 export { Loader } from './ui/loader';
 export { KakaoShareButton } from './ui/KakaoShareButton';
+export { Toast } from './ui/Toast';
 
 // lib

--- a/src/shared/ui/KakaoShareButton.tsx
+++ b/src/shared/ui/KakaoShareButton.tsx
@@ -1,18 +1,22 @@
 'use client';
 
-import { useState } from 'react';
 import { KakaoShareButtonProps } from '../model/type';
+import {
+  useExperimentLog,
+  useToastMessageStore,
+} from '@/features/article-analyze';
 
 export function KakaoShareButton({
   title,
   description,
   url,
 }: KakaoShareButtonProps) {
-  const [log, setLog] = useState('');
+  const { log } = useExperimentLog();
+  const { setToastMessage } = useToastMessageStore();
 
   const handleShare = () => {
     if (!window.Kakao) {
-      setLog('Kakao SDK 미로드');
+      setToastMessage('Kakao SDK 미로드');
       return;
     }
 
@@ -21,7 +25,7 @@ export function KakaoShareButton({
     }
 
     if (!window.Kakao.isInitialized()) {
-      setLog('초기화 실패: ' + process.env.NEXT_PUBLIC_KAKAO_JS_KEY);
+      setToastMessage('초기화 실패');
       return;
     }
 
@@ -38,9 +42,13 @@ export function KakaoShareButton({
           },
         },
       });
-      setLog('sendDefault 호출 완료');
+      setToastMessage('sendDefault 호출 완료');
+      log({
+        query: title,
+        eventType: 'kakao_share',
+      });
     } catch (e) {
-      setLog('공유 실패: ' + String(e));
+      setToastMessage('공유 실패: ' + String(e));
     }
   };
 
@@ -53,7 +61,6 @@ export function KakaoShareButton({
       >
         카카오톡 공유
       </button>
-      {log && <div className="mt-2 text-xs text-red-500 break-all">{log}</div>}
     </div>
   );
 }

--- a/src/shared/ui/Toast.tsx
+++ b/src/shared/ui/Toast.tsx
@@ -1,18 +1,18 @@
-// shared/ui/Toast.tsx
 'use client';
 
+import { useToastMessageStore } from '@/features/article-analyze';
 import { useEffect } from 'react';
 
-interface ToastProps {
-  message: string;
-  onClose: () => void;
-}
+export function Toast() {
+  const { message, clearToastMessage } = useToastMessageStore();
 
-export function Toast({ message, onClose }: ToastProps) {
   useEffect(() => {
-    const timer = setTimeout(onClose, 3000);
+    if (!message) return;
+    const timer = setTimeout(clearToastMessage, 3000);
     return () => clearTimeout(timer);
-  }, [onClose]);
+  }, [message, clearToastMessage]);
+
+  if (!message) return null;
 
   return (
     <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 px-4 py-3 bg-gray-900 text-white text-sm rounded-xl shadow-lg animate-fade-in">

--- a/src/shared/ui/Toast.tsx
+++ b/src/shared/ui/Toast.tsx
@@ -1,0 +1,22 @@
+// shared/ui/Toast.tsx
+'use client';
+
+import { useEffect } from 'react';
+
+interface ToastProps {
+  message: string;
+  onClose: () => void;
+}
+
+export function Toast({ message, onClose }: ToastProps) {
+  useEffect(() => {
+    const timer = setTimeout(onClose, 3000);
+    return () => clearTimeout(timer);
+  }, [onClose]);
+
+  return (
+    <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 px-4 py-3 bg-gray-900 text-white text-sm rounded-xl shadow-lg animate-fade-in">
+      {message}
+    </div>
+  );
+}

--- a/src/widgets/analyze-entry/ui/ArticleAnalyzeSection.tsx
+++ b/src/widgets/analyze-entry/ui/ArticleAnalyzeSection.tsx
@@ -87,6 +87,7 @@ export function ArticleAnalyzeSection() {
           isAnalyzeError={isAnalyzeError}
         />
       )}
+
       <PasteSection
         value={pasteText}
         onChange={handlePasteTextChange}

--- a/src/widgets/analyze-entry/ui/ArticleAnalyzeSection.tsx
+++ b/src/widgets/analyze-entry/ui/ArticleAnalyzeSection.tsx
@@ -11,14 +11,21 @@ import {
   useSearchModel,
   useSelectedNewsStore,
 } from '@/features/article-analyze';
-import { Loader } from '@/shared';
+import { Loader, Toast } from '@/shared';
 
 export function ArticleAnalyzeSection() {
   const [query, setQuery] = useState('');
   const { selectedNews } = useSelectedNewsStore();
 
-  const { mode, toggleMode, handleSearch, searchData, isSuccess, isLoading } =
-    useSearchModel();
+  const {
+    mode,
+    toggleMode,
+    handleSearch,
+    searchData,
+    isSuccess,
+    isLoading,
+    isSearchError,
+  } = useSearchModel();
 
   const {
     pasteText,
@@ -33,11 +40,10 @@ export function ArticleAnalyzeSection() {
     handleCompare,
     handleAnalyze,
     isPending: isAnalyzePending,
+    toastMessage,
+    clearToast,
+    isAnalyzeError,
   } = useAnalyzeModel(mode, query);
-
-  // useEffect(() => {
-  //   console.log('selected articles:', selectedNews);
-  // }, [selectedNews]);
 
   return (
     <form onSubmit={(e) => handleSearch(e, query)} className="mb-6">
@@ -55,7 +61,22 @@ export function ArticleAnalyzeSection() {
         </div>
       )}
       {isLoading && <Loader />}
-      {!isLoading && isSuccess && (
+
+      {/* 검색 실패 */}
+      {!isLoading && isSearchError && (
+        <p className="text-sm text-gray-400 text-center py-8">
+          검색 중 오류가 발생했습니다. 다시 시도해주세요.
+        </p>
+      )}
+
+      {/* 빈 결과 */}
+      {!isLoading && isSuccess && !searchData?.groups?.length && (
+        <p className="text-sm text-gray-400 text-center py-8">
+          검색 결과가 없습니다.
+        </p>
+      )}
+
+      {!isLoading && isSuccess && !!searchData?.groups?.length && (
         <ArticleList
           articles={searchData}
           selected={selectedNews}
@@ -63,6 +84,7 @@ export function ArticleAnalyzeSection() {
           canCompare={canCompare}
           handleCompare={() => handleCompare(selectedNews, query)}
           isPending={isAnalyzePending}
+          isAnalyzeError={isAnalyzeError}
         />
       )}
       <PasteSection
@@ -74,6 +96,8 @@ export function ArticleAnalyzeSection() {
       />
 
       <RecentAnalysesList />
+
+      {toastMessage && <Toast message={toastMessage} onClose={clearToast} />}
     </form>
   );
 }

--- a/src/widgets/analyze-entry/ui/ArticleAnalyzeSection.tsx
+++ b/src/widgets/analyze-entry/ui/ArticleAnalyzeSection.tsx
@@ -11,14 +11,12 @@ import {
   useArticleSelectState,
   useSearchModel,
   useSelectedNewsStore,
-  useToastMessageStore,
 } from '@/features/article-analyze';
 import { Loader, Toast } from '@/shared';
 
 export function ArticleAnalyzeSection() {
   const [query, setQuery] = useState('');
   const { selectedNews } = useSelectedNewsStore();
-  const { message } = useToastMessageStore();
 
   const { mode, toggleMode, handleSearch, searchData, isSuccess, isLoading } =
     useSearchModel();

--- a/src/widgets/analyze-entry/ui/ArticleAnalyzeSection.tsx
+++ b/src/widgets/analyze-entry/ui/ArticleAnalyzeSection.tsx
@@ -6,26 +6,22 @@ import {
   PasteSection,
   RecentAnalysesList,
   SearchBar,
+  ToggleButton,
   useAnalyzeModel,
   useArticleSelectState,
   useSearchModel,
   useSelectedNewsStore,
+  useToastMessageStore,
 } from '@/features/article-analyze';
 import { Loader, Toast } from '@/shared';
 
 export function ArticleAnalyzeSection() {
   const [query, setQuery] = useState('');
   const { selectedNews } = useSelectedNewsStore();
+  const { message } = useToastMessageStore();
 
-  const {
-    mode,
-    toggleMode,
-    handleSearch,
-    searchData,
-    isSuccess,
-    isLoading,
-    isSearchError,
-  } = useSearchModel();
+  const { mode, toggleMode, handleSearch, searchData, isSuccess, isLoading } =
+    useSearchModel();
 
   const {
     pasteText,
@@ -40,8 +36,6 @@ export function ArticleAnalyzeSection() {
     handleCompare,
     handleAnalyze,
     isPending: isAnalyzePending,
-    toastMessage,
-    clearToast,
     isAnalyzeError,
   } = useAnalyzeModel(mode, query);
 
@@ -50,31 +44,10 @@ export function ArticleAnalyzeSection() {
       <SearchBar value={query} onChange={(e) => setQuery(e.target.value)} />
       {/* A/B 토글 — 검색 결과 있을 때만 표시 */}
       {isSuccess && !isLoading && (
-        <div className="flex justify-end mb-2">
-          <button
-            type="button"
-            onClick={toggleMode}
-            className="text-xs px-3 py-1.5 rounded-lg border border-gray-200 text-gray-400 hover:border-gray-300 hover:text-gray-600 transition-colors"
-          >
-            {mode === 'cluster' ? '📋 목록 보기' : '🗂 그룹 보기'}
-          </button>
-        </div>
+        <ToggleButton mode={mode} toggleMode={toggleMode} />
       )}
+
       {isLoading && <Loader />}
-
-      {/* 검색 실패 */}
-      {!isLoading && isSearchError && (
-        <p className="text-sm text-gray-400 text-center py-8">
-          검색 중 오류가 발생했습니다. 다시 시도해주세요.
-        </p>
-      )}
-
-      {/* 빈 결과 */}
-      {!isLoading && isSuccess && !searchData?.groups?.length && (
-        <p className="text-sm text-gray-400 text-center py-8">
-          검색 결과가 없습니다.
-        </p>
-      )}
 
       {!isLoading && isSuccess && !!searchData?.groups?.length && (
         <ArticleList
@@ -98,7 +71,7 @@ export function ArticleAnalyzeSection() {
 
       <RecentAnalysesList />
 
-      {toastMessage && <Toast message={toastMessage} onClose={clearToast} />}
+      <Toast />
     </form>
   );
 }


### PR DESCRIPTION
### 제목 : feat: 실험 로그 고도화 (kakao_share, original_link_click 이벤트 추가)

### 🖇️ 관련 이슈
- 없음

### 🔎 작업 내용
- `kakao_share` 이벤트 추가 — 카카오 공유 버튼 클릭 시 로깅
- `original_link_click` 이벤트 추가 — 원문 링크 클릭 시 로깅 (article_link 포함)
- `OriginalLinkButton` Client Component 분리 — onClick 이벤트 처리를 위해 `'use client'` 선언

### ➕ 추가 설명
- Server Component에서 onClick 핸들러 전달 시 에러 발생 → `'use client'` 추가로 해결
- 현재 수집 이벤트: `deselect` / `compare_start` / `kakao_share` / `original_link_click`
- dev / production 모두 로깅, 조회 시 `where environment = 'production'` 필터로 실사용 데이터 분석