### PR TITLE
[Refactor] widgets 삭제, 검색 상태 model 폴더로 분리

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { ArticleAnalyzeSection } from '@/widgets/analyze-entry';
+import { ArticleAnalyzeSection } from '@/features/article-analyze';
 
 export default function Home() {
   return (

--- a/src/features/article-analyze/index.ts
+++ b/src/features/article-analyze/index.ts
@@ -6,7 +6,8 @@ export { ArticleCard } from './ui/ArticleCard';
 export { CopyButton } from './ui/CopyButton';
 export { RecentAnalysesList } from './ui/RecentAnalysesList';
 export { ToggleButton } from './ui/ToggleButton';
-export {OriginalLinkButton} from './ui/OriginalLinkButton';
+export { OriginalLinkButton } from './ui/OriginalLinkButton';
+export { ArticleAnalyzeSection } from './ui/ArticleAnalyzeSection';
 
 //api
 export { useNewsSearch } from './api/useNewsSearch';

--- a/src/features/article-analyze/model/useSearchModel.ts
+++ b/src/features/article-analyze/model/useSearchModel.ts
@@ -8,6 +8,7 @@ import { useSelectedNewsStore } from './useSelectedNewsStore';
 
 export function useSearchModel() {
   const [mode, setMode] = useState<SearchMode>('cluster');
+  const [query, setQuery] = useState('');
   const { clearNews } = useSelectedNewsStore();
 
   const {
@@ -42,6 +43,11 @@ export function useSearchModel() {
   const flatAsCluster = searchData
     ? { groups: [{ topic: '검색 결과', articles: searchData.items }] }
     : undefined;
+  
+  
+    const handleQuery = (e: React.ChangeEvent<HTMLInputElement>) => {
+      setQuery(e.target.value);
+    };
 
   return {
     mode,
@@ -50,5 +56,7 @@ export function useSearchModel() {
     searchData: mode === 'cluster' ? clusterData : flatAsCluster,
     isSuccess: mode === 'cluster' ? !!clusterData : !!flatAsCluster,
     isLoading: isSearching || (mode === 'cluster' && isClustering),
+    query,
+    handleQuery,
   };
 }

--- a/src/features/article-analyze/ui/ArticleAnalyzeSection.tsx
+++ b/src/features/article-analyze/ui/ArticleAnalyzeSection.tsx
@@ -1,25 +1,29 @@
 'use client';
 
-import { useState } from 'react';
-import {
-  ArticleList,
-  PasteSection,
-  RecentAnalysesList,
-  SearchBar,
-  ToggleButton,
-  useAnalyzeModel,
-  useArticleSelectState,
-  useSearchModel,
-  useSelectedNewsStore,
-} from '@/features/article-analyze';
 import { Loader, Toast } from '@/shared';
+import { useSelectedNewsStore } from '../model/useSelectedNewsStore';
+import { useAnalyzeModel } from '../model/useAnalyzeModel';
+import { useArticleSelectState } from '../model/useArticleSelectState';
+import { useSearchModel } from '../model/useSearchModel';
+import { ArticleList } from './ArticleList';
+import { PasteSection } from './PasteSection';
+import { RecentAnalysesList } from './RecentAnalysesList';
+import { SearchBar } from './SearchBar';
+import { ToggleButton } from './ToggleButton';
 
 export function ArticleAnalyzeSection() {
-  const [query, setQuery] = useState('');
   const { selectedNews } = useSelectedNewsStore();
 
-  const { mode, toggleMode, handleSearch, searchData, isSuccess, isLoading } =
-    useSearchModel();
+  const {
+    mode,
+    toggleMode,
+    handleSearch,
+    searchData,
+    isSuccess,
+    isLoading,
+    query,
+    handleQuery,
+  } = useSearchModel();
 
   const {
     pasteText,
@@ -39,7 +43,7 @@ export function ArticleAnalyzeSection() {
 
   return (
     <form onSubmit={(e) => handleSearch(e, query)} className="mb-6">
-      <SearchBar value={query} onChange={(e) => setQuery(e.target.value)} />
+      <SearchBar value={query} onChange={handleQuery} />
       {/* A/B 토글 — 검색 결과 있을 때만 표시 */}
       {isSuccess && !isLoading && (
         <ToggleButton mode={mode} toggleMode={toggleMode} />

--- a/src/widgets/analyze-entry/index.ts
+++ b/src/widgets/analyze-entry/index.ts
@@ -1,1 +1,0 @@
-export {ArticleAnalyzeSection} from "./ui/ArticleAnalyzeSection"


### PR DESCRIPTION
### 제목 : widgets 삭제, 검색 상태 model 폴더로 분리

### 🖇️ 관련 이슈

- #15 

### 🔎 작업 내용
- widgets 삭제
- query 상태 model 폴더로 분리


<br/>
close #15