### PR TITLE
[Bugfix] 뉴스 플랫폼 형식 오류 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-dom": "19.2.4",
     "shadcn": "^4.4.0",
     "tailwind-merge": "^3.5.0",
+    "tldts": "^7.0.30",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
+      tldts:
+        specifier: ^7.0.30
+        version: 7.0.30
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
@@ -3618,11 +3621,11 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
-  tldts-core@7.0.28:
-    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+  tldts-core@7.0.30:
+    resolution: {integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==}
 
-  tldts@7.0.28:
-    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
+  tldts@7.0.30:
+    resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
     hasBin: true
 
   to-regex-range@5.0.1:
@@ -7707,11 +7710,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  tldts-core@7.0.28: {}
+  tldts-core@7.0.30: {}
 
-  tldts@7.0.28:
+  tldts@7.0.30:
     dependencies:
-      tldts-core: 7.0.28
+      tldts-core: 7.0.30
 
   to-regex-range@5.0.1:
     dependencies:
@@ -7721,7 +7724,7 @@ snapshots:
 
   tough-cookie@6.0.1:
     dependencies:
-      tldts: 7.0.28
+      tldts: 7.0.30
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:

--- a/src/app/api/site-name/route.ts
+++ b/src/app/api/site-name/route.ts
@@ -1,0 +1,38 @@
+const extractDomain = (url: string): string => {
+  const hostname = new URL(url).hostname;
+  return hostname
+    .replace(/^www\./, '')
+    .replace(/\.(com|co\.kr|net|org|kr)$/, '');
+};
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const url = searchParams.get('url');
+
+  if (!url) return Response.json({ siteName: null }, { status: 400 });
+
+  try {
+    const response = await fetch(url);
+    const buffer = await response.arrayBuffer();
+
+    const contentType = response.headers.get('content-type') ?? '';
+    const rawHtml = new TextDecoder('utf-8').decode(buffer);
+    const isEucKr =
+      contentType.toLowerCase().includes('euc-kr') ||
+      rawHtml.toLowerCase().includes('charset=euc-kr');
+
+    const html = isEucKr ? new TextDecoder('euc-kr').decode(buffer) : rawHtml;
+
+    const match = html.match(
+      /<meta[^>]*property="og:site_name"[^>]*content="([^"]+)"/,
+    );
+    const raw = match?.[1] ?? null;
+
+    const siteName = raw && !/[-|]/.test(raw) ? raw : extractDomain(url);
+
+    return Response.json({ siteName });
+  } catch {
+    // fetch 자체 실패 시에도 도메인 fallback
+    return Response.json({ siteName: extractDomain(url) });
+  }
+}

--- a/src/app/api/site-name/route.ts
+++ b/src/app/api/site-name/route.ts
@@ -1,8 +1,8 @@
+import { parse } from 'tldts';
+
 const extractDomain = (url: string): string => {
-  const hostname = new URL(url).hostname;
-  return hostname
-    .replace(/^www\./, '')
-    .replace(/\.(com|co\.kr|net|org|kr)$/, '');
+  const { domainWithoutSuffix } = parse(url);
+  return domainWithoutSuffix ?? new URL(url).hostname;
 };
 
 export async function GET(request: Request) {

--- a/src/features/article-analyze/lib/newspaperFormat.ts
+++ b/src/features/article-analyze/lib/newspaperFormat.ts
@@ -1,3 +1,5 @@
+import axios from "axios";
+
 const SOURCE_MAP: Record<string, string> = {
   // 통신사
   'www.yna.co.kr': '연합뉴스',
@@ -89,11 +91,21 @@ const SOURCE_MAP: Record<string, string> = {
   'mbn.co.kr': 'MBN',
 };
 
-export function getSourceName(originallink: string) {
-  try {
-    const domain = new URL(originallink).hostname;
-    return SOURCE_MAP[domain] ?? domain; // 매핑 없으면 도메인 그대로 반환
-  } catch {
-    return '알 수 없음';
-  }
+export async function getSourceName(url: string): Promise<string> {
+  // SOURCE_MAP 우선
+  const mapped = SOURCE_MAP[url];
+  if (mapped) return mapped;
+
+  // 없으면 og:site_name 파싱
+  const { data } = await axios.get('/api/site-name', { params: { url } });
+  return data.siteName ?? new URL(url).hostname; // 최후 fallback은 hostname
 }
+
+// export function getSourceName(originallink: string) {
+//   try {
+//     const domain = new URL(originallink).hostname;
+//     return SOURCE_MAP[domain] ?? domain; // 매핑 없으면 도메인 그대로 반환
+//   } catch {
+//     return '알 수 없음';
+//   }
+// }

--- a/src/features/article-analyze/lib/useSourceName.ts
+++ b/src/features/article-analyze/lib/useSourceName.ts
@@ -1,0 +1,17 @@
+import { useState, useEffect } from "react";
+import { getSourceName } from "./newspaperFormat";
+
+export function useSourceName(url: string) {
+  const [sourceName, setSourceName] = useState('');
+
+  useEffect(() => {
+    const fetch = async () => {
+      const name = await getSourceName(url);
+      setSourceName(name);
+    };
+
+    fetch();
+  }, [url]);
+
+  return sourceName;
+}

--- a/src/features/article-analyze/model/type.ts
+++ b/src/features/article-analyze/model/type.ts
@@ -1,10 +1,5 @@
 import { ArticleInput } from './schemas';
 
-export interface SearchBarProps {
-  value: string;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-}
-
 export interface ArticleListProps {
   articles: ClusterResult | undefined;
   selected: NewsItem[];
@@ -13,14 +8,6 @@ export interface ArticleListProps {
   handleCompare: () => void;
   isPending: boolean;
   isAnalyzeError: boolean;
-}
-
-export interface PasteSectionProps {
-  value: string;
-  onChange: (v: string) => void;
-  canAnalyze: boolean;
-  onReset: () => void;
-  handleAnalyze: () => void;
 }
 
 export interface NewsItem {
@@ -53,7 +40,7 @@ export type NaverArticle = {
 };
 
 type ArticleGroup = {
-  topic: string; 
+  topic: string;
   articles: NaverArticle[];
 };
 

--- a/src/features/article-analyze/model/useAnalyzeModel.ts
+++ b/src/features/article-analyze/model/useAnalyzeModel.ts
@@ -9,17 +9,19 @@ export function useAnalyzeModel(mode: SearchMode, query: string) {
   const { mutate: analyze, isPending, isError: isAnalyzeError } = useAnalyze();
   const { log } = logExperiment();
 
-  const handleCompare = (selected: NewsItem[], keyword: string) => {
-    log({ mode, query, eventType: 'compare_start' }); // 비교 시작 로그
-    analyze({
-      keyword,
-      articles: selected.map((article) => ({
+  const handleCompare = async (selected: NewsItem[], keyword: string) => {
+    log({ mode, query, eventType: 'compare_start' });
+
+    const articles = await Promise.all(
+      selected.map(async (article) => ({
         title: stripHtml(article.title),
         content: stripHtml(article.description),
-        source: getSourceName(article.originallink),
+        source: await getSourceName(article.originallink),
         originallink: article.originallink,
       })),
-    });
+    );
+
+    analyze({ keyword, articles });
   };
 
   const handleAnalyze = (pasteText: string) => {

--- a/src/features/article-analyze/model/useAnalyzeModel.ts
+++ b/src/features/article-analyze/model/useAnalyzeModel.ts
@@ -24,16 +24,8 @@ export function useAnalyzeModel(mode: SearchMode, query: string) {
     analyze({ keyword, articles });
   };
 
-  const handleAnalyze = (pasteText: string) => {
-    analyze({
-      keyword: '붙여넣기 분석',
-      articles: [{ title: '', content: pasteText }],
-    });
-  };
-
   return {
     handleCompare,
-    handleAnalyze,
     isPending,
     isAnalyzeError,
   };

--- a/src/features/article-analyze/model/useArticleSelectState.ts
+++ b/src/features/article-analyze/model/useArticleSelectState.ts
@@ -15,7 +15,6 @@ export function useArticleSelectState(
   const toggleArticle = (article: NewsItem) => {
     const isDeselecting = selectedNews.some((a) => a.link === article.link);
 
-    // 오선택 취소 시 로그 기록
     if (isDeselecting) {
       log({
         mode,

--- a/src/features/article-analyze/model/useArticleSelectState.ts
+++ b/src/features/article-analyze/model/useArticleSelectState.ts
@@ -1,5 +1,4 @@
 'use client';
-import { useState } from 'react';
 import type { NewsItem, SearchMode } from './type';
 import { logExperiment } from '../api/logExperiment';
 import { useSelectedNewsStore } from './useSelectedNewsStore';
@@ -9,8 +8,7 @@ export function useArticleSelectState(
   query: string,
   selectedNews: NewsItem[],
 ) {
-  const [pasteText, setPasteText] = useState('');
-  const { addNews, clearNews } = useSelectedNewsStore();
+  const { addNews } = useSelectedNewsStore();
 
   const { log } = logExperiment();
 
@@ -30,21 +28,8 @@ export function useArticleSelectState(
     addNews(article);
   };
 
-  const handleReset = () => {
-    clearNews();
-    setPasteText('');
-  };
-
-  const handlePasteTextChange = (text: string) => {
-    setPasteText(text);
-  };
-
   return {
-    pasteText,
-    handlePasteTextChange,
     toggleArticle,
-    handleReset,
     canCompare: selectedNews.length === 2,
-    canAnalyze: pasteText.trim().length > 0,
   };
 }

--- a/src/features/article-analyze/model/usePaste.ts
+++ b/src/features/article-analyze/model/usePaste.ts
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import { useAnalyze } from './useAnalyze';
+import { useSelectedNewsStore } from './useSelectedNewsStore';
+
+export function usePaste() {
+  const { mutate: analyze } = useAnalyze();
+  const [pasteText, setPasteText] = useState<string>('');
+  const { clearNews } = useSelectedNewsStore();
+
+  const handleReset = () => {
+    clearNews();
+    setPasteText('');
+  };
+
+  const canAnalyze = pasteText.trim().length > 0;
+
+  const handleAnalyze = (pasteText: string) => {
+    analyze({
+      keyword: '붙여넣기 분석',
+      articles: [{ title: '', content: pasteText }],
+    });
+  };
+
+  const onSubmit = (e: React.SubmitEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    handleAnalyze(pasteText);
+  };
+
+  const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) =>
+    setPasteText(e.target.value);
+
+  return {
+    canAnalyze,
+    onReset: handleReset,
+    onSubmit,
+    onChange,
+    pasteText,
+  };
+}

--- a/src/features/article-analyze/model/useSearch.ts
+++ b/src/features/article-analyze/model/useSearch.ts
@@ -1,0 +1,11 @@
+import React, { useState } from 'react';
+
+export function useSearch() {
+  const [query, setQuery] = useState<string>('');
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(e.target.value);
+  };
+
+  return { onChange, query };
+}

--- a/src/features/article-analyze/model/useSearchModel.ts
+++ b/src/features/article-analyze/model/useSearchModel.ts
@@ -30,8 +30,7 @@ export function useSearchModel() {
     },
   });
 
-  const handleSearch = (e: React.FormEvent<HTMLFormElement>, query: string) => {
-    e.preventDefault();
+  const handleSearch = (query: string) => {
     if (query.trim()) searchNews(query);
   };
 

--- a/src/features/article-analyze/model/useSearchModel.ts
+++ b/src/features/article-analyze/model/useSearchModel.ts
@@ -38,7 +38,6 @@ export function useSearchModel() {
     setMode((prev) => (prev === 'cluster' ? 'flat' : 'cluster'));
   };
 
-  // flat 모드: 검색 결과를 ClusterResult 형태로 래핑해서 반환
   const flatAsCluster = searchData
     ? { groups: [{ topic: '검색 결과', articles: searchData.items }] }
     : undefined;

--- a/src/features/article-analyze/ui/ArticleAnalyzeSection.tsx
+++ b/src/features/article-analyze/ui/ArticleAnalyzeSection.tsx
@@ -44,8 +44,10 @@ export function ArticleAnalyzeSection() {
         <ToggleButton mode={mode} toggleMode={toggleMode} />
       )}
 
+      {/* 검색 로더 */}
       {isLoading && <Loader />}
 
+      {/* 검색 결과 */}
       {!isLoading && isSuccess && !!searchData?.groups?.length && (
         <ArticleList
           articles={searchData}
@@ -57,11 +59,12 @@ export function ArticleAnalyzeSection() {
           isAnalyzeError={isAnalyzeError}
         />
       )}
-
+      {/* 붙여넣기 분석 섹션 — 검색 결과 없을 때 표시 */}
       <PasteSection />
 
+      {/* 최근 분석 리스트 */}
       <RecentAnalysesList />
-
+      {/* 토스트 메세지 */}
       <Toast />
     </div>
   );

--- a/src/features/article-analyze/ui/ArticleAnalyzeSection.tsx
+++ b/src/features/article-analyze/ui/ArticleAnalyzeSection.tsx
@@ -17,33 +17,28 @@ export function ArticleAnalyzeSection() {
   const {
     mode,
     toggleMode,
-    handleSearch,
     searchData,
     isSuccess,
     isLoading,
     query,
-    handleQuery,
+    handleSearch,
   } = useSearchModel();
 
-  const {
-    pasteText,
-    handlePasteTextChange,
-    toggleArticle,
-    handleReset,
-    canCompare,
-    canAnalyze,
-  } = useArticleSelectState(mode, query, selectedNews);
+  const { toggleArticle, canCompare } = useArticleSelectState(
+    mode,
+    query,
+    selectedNews,
+  );
 
   const {
     handleCompare,
-    handleAnalyze,
     isPending: isAnalyzePending,
     isAnalyzeError,
   } = useAnalyzeModel(mode, query);
 
   return (
-    <form onSubmit={(e) => handleSearch(e, query)} className="mb-6">
-      <SearchBar value={query} onChange={handleQuery} />
+    <div className="mb-6">
+      <SearchBar onSubmit={handleSearch} />
       {/* A/B 토글 — 검색 결과 있을 때만 표시 */}
       {isSuccess && !isLoading && (
         <ToggleButton mode={mode} toggleMode={toggleMode} />
@@ -63,17 +58,11 @@ export function ArticleAnalyzeSection() {
         />
       )}
 
-      <PasteSection
-        value={pasteText}
-        onChange={handlePasteTextChange}
-        canAnalyze={canAnalyze}
-        onReset={handleReset}
-        handleAnalyze={() => handleAnalyze(pasteText)}
-      />
+      <PasteSection />
 
       <RecentAnalysesList />
 
       <Toast />
-    </form>
+    </div>
   );
 }

--- a/src/features/article-analyze/ui/ArticleCard.tsx
+++ b/src/features/article-analyze/ui/ArticleCard.tsx
@@ -12,14 +12,14 @@ export function ArticleCard({
   tone: { bg: string; text: string; border: string; label: string };
   title: string;
 }) {
- const [expanded, setExpanded] = useState(false);
- const [isClamped, setIsClamped] = useState(false);
- const textRef = useRef<HTMLParagraphElement>(null);
+  const [expanded, setExpanded] = useState(false);
+  const [isClamped, setIsClamped] = useState(false);
+  const textRef = useRef<HTMLParagraphElement>(null);
 
- useEffect(() => {
-   const el = textRef.current;
-   if (el) setIsClamped(el.scrollHeight > el.clientHeight);
- }, [title]);
+  useEffect(() => {
+    const el = textRef.current;
+    if (el) setIsClamped(el.scrollHeight > el.clientHeight);
+  }, [title]);
 
   return (
     <div className="bg-gray-50 rounded-xl p-4">

--- a/src/features/article-analyze/ui/ArticleItem.tsx
+++ b/src/features/article-analyze/ui/ArticleItem.tsx
@@ -1,0 +1,57 @@
+import { dateFormat } from "../lib/dateFormat";
+import { stripHtml } from "../lib/striphtml";
+import { useSourceName } from "../lib/useSourceName";
+import { NewsItem } from "../model/type";
+
+export function ArticleItem({
+  article,
+  isSelected,
+  onToggle,
+  idx,
+}: {
+  article: NewsItem;
+  isSelected: boolean;
+  onToggle: (article: NewsItem, idx: number) => void;
+  idx: number;
+}) {
+  const sourceName = useSourceName(article.originallink);
+
+  return (
+    <button
+      key={idx}
+      onClick={() => onToggle(article, idx)}
+      type="button"
+      className={`flex items-start gap-3 px-4 py-3 border rounded-lg text-left transition-colors ${
+        isSelected
+          ? 'border-emerald-200 bg-emerald-50'
+          : 'border-gray-100 hover:border-gray-200 hover:bg-gray-50'
+      }`}
+    >
+      <div
+        className={`mt-0.5 w-4 h-4 rounded shrink-0 flex items-center justify-center transition-colors ${
+          isSelected ? 'bg-emerald-500' : 'border border-gray-300'
+        }`}
+      >
+        {isSelected && (
+          <svg width="10" height="8" viewBox="0 0 10 8" fill="none">
+            <path
+              d="M1 4l2.5 2.5L9 1"
+              stroke="white"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        )}
+      </div>
+      <div>
+        <p className="text-xs text-gray-400 mb-0.5">
+          {sourceName} · {dateFormat(article.pubDate)}
+        </p>
+        <p className="text-sm text-gray-800 leading-relaxed">
+          {stripHtml(article.title)}
+        </p>
+      </div>
+    </button>
+  );
+}

--- a/src/features/article-analyze/ui/ArticleItem.tsx
+++ b/src/features/article-analyze/ui/ArticleItem.tsx
@@ -1,7 +1,7 @@
-import { dateFormat } from "../lib/dateFormat";
-import { stripHtml } from "../lib/striphtml";
-import { useSourceName } from "../lib/useSourceName";
-import { NewsItem } from "../model/type";
+import { dateFormat } from '../lib/dateFormat';
+import { stripHtml } from '../lib/striphtml';
+import { useSourceName } from '../lib/useSourceName';
+import { NewsItem } from '../model/type';
 
 export function ArticleItem({
   article,

--- a/src/features/article-analyze/ui/ArticleList.tsx
+++ b/src/features/article-analyze/ui/ArticleList.tsx
@@ -10,9 +10,8 @@ export function ArticleList({
   canCompare,
   handleCompare,
   isPending,
-  isAnalyzeError
+  isAnalyzeError,
 }: ArticleListProps) {
-  
   return (
     <div className="flex flex-col gap-4 mb-7">
       {articles?.groups.map((group, groupIdx) => (

--- a/src/features/article-analyze/ui/ArticleList.tsx
+++ b/src/features/article-analyze/ui/ArticleList.tsx
@@ -1,10 +1,7 @@
 'use client';
-
-import { dateFormat } from '../lib/dateFormat';
-import { getSourceName } from '../lib/newspaperFormat';
-import { stripHtml } from '../lib/striphtml';
 import { ArticleListProps } from '../model/type';
 import { Button } from '@/shared';
+import { ArticleItem } from './ArticleItem';
 
 export function ArticleList({
   articles,
@@ -15,6 +12,7 @@ export function ArticleList({
   isPending,
   isAnalyzeError
 }: ArticleListProps) {
+  
   return (
     <div className="flex flex-col gap-4 mb-7">
       {articles?.groups.map((group, groupIdx) => (
@@ -28,43 +26,13 @@ export function ArticleList({
           {group.articles.map((article, idx) => {
             const isSelected = selected.some((a) => a.link === article.link);
             return (
-              <button
+              <ArticleItem
                 key={idx}
-                onClick={() => onToggle(article, idx)}
-                type="button"
-                className={`flex items-start gap-3 px-4 py-3 border rounded-lg text-left transition-colors ${
-                  isSelected
-                    ? 'border-emerald-200 bg-emerald-50'
-                    : 'border-gray-100 hover:border-gray-200 hover:bg-gray-50'
-                }`}
-              >
-                <div
-                  className={`mt-0.5 w-4 h-4 rounded shrink-0 flex items-center justify-center transition-colors ${
-                    isSelected ? 'bg-emerald-500' : 'border border-gray-300'
-                  }`}
-                >
-                  {isSelected && (
-                    <svg width="10" height="8" viewBox="0 0 10 8" fill="none">
-                      <path
-                        d="M1 4l2.5 2.5L9 1"
-                        stroke="white"
-                        strokeWidth="1.5"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      />
-                    </svg>
-                  )}
-                </div>
-                <div>
-                  <p className="text-xs text-gray-400 mb-0.5">
-                    {getSourceName(article.originallink)} ·{' '}
-                    {dateFormat(article.pubDate)}
-                  </p>
-                  <p className="text-sm text-gray-800 leading-relaxed">
-                    {stripHtml(article.title)}
-                  </p>
-                </div>
-              </button>
+                article={article}
+                isSelected={isSelected}
+                onToggle={onToggle}
+                idx={idx}
+              />
             );
           })}
         </div>

--- a/src/features/article-analyze/ui/CopyButton.tsx
+++ b/src/features/article-analyze/ui/CopyButton.tsx
@@ -2,7 +2,7 @@
 import { useState } from 'react';
 
 export function CopyButton() {
-  const [copied, setCopied] = useState(false);
+  const [copied, setCopied] = useState<boolean>(false);
 
   const handleCopy = async () => {
     await navigator.clipboard.writeText(window.location.href);

--- a/src/features/article-analyze/ui/PasteSection.tsx
+++ b/src/features/article-analyze/ui/PasteSection.tsx
@@ -1,16 +1,12 @@
 'use client';
 
-import { PasteSectionProps } from '../model/type';
+import { usePaste } from '../model/usePaste';
 
-export function PasteSection({
-  value,
-  onChange,
-  canAnalyze,
-  onReset,
-  handleAnalyze,
-}: PasteSectionProps) {
+export function PasteSection() {
+  const { canAnalyze, onReset, onSubmit, onChange, pasteText } = usePaste();
+
   return (
-    <>
+    <form onSubmit={onSubmit}>
       <div className="flex items-center gap-3 mb-6">
         <div className="flex-1 h-px bg-gray-100" />
         <span className="text-xs text-gray-400">또는 본문 직접 분석</span>
@@ -18,8 +14,8 @@ export function PasteSection({
       </div>
 
       <textarea
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
+        value={pasteText}
+        onChange={onChange}
         placeholder="기사 본문을 여기에 붙여넣으세요…"
         className="w-full min-h-27.5 px-4 py-3 text-sm border border-gray-100 rounded-lg bg-gray-50 text-gray-800 placeholder:text-gray-400 outline-none focus:border-gray-300 focus:bg-white transition-colors resize-none leading-relaxed"
       />
@@ -33,9 +29,8 @@ export function PasteSection({
           초기화
         </button>
         <button
-          onClick={handleAnalyze}
+          type="submit"
           disabled={!canAnalyze}
-          type="button"
           className={`h-9 px-5 text-sm font-medium rounded-lg transition-colors cursor-pointer ${
             canAnalyze
               ? 'bg-emerald-600 text-white hover:bg-emerald-600/70'
@@ -45,6 +40,6 @@ export function PasteSection({
           단독 분석
         </button>
       </div>
-    </>
+    </form>
   );
 }

--- a/src/features/article-analyze/ui/RecentAnalysesList.tsx
+++ b/src/features/article-analyze/ui/RecentAnalysesList.tsx
@@ -4,11 +4,12 @@ import Link from 'next/link';
 import { useRecentAnalyses } from '../api/useRecentAnalyses';
 import { dateFormat } from '../lib/dateFormat';
 import { RecentAnalysis } from '../model/type';
+import { Loader } from '@/shared';
 
 export function RecentAnalysesList() {
   const { data, isLoading } = useRecentAnalyses();
 
-  if (isLoading) return null;
+  if (isLoading) return <Loader />;
   if (!data?.length) return null;
 
   return (

--- a/src/features/article-analyze/ui/SearchBar.tsx
+++ b/src/features/article-analyze/ui/SearchBar.tsx
@@ -1,23 +1,30 @@
 'use client';
+import { useSearch } from '../model/useSearch';
 
-import { SearchBarProps } from '../model/type';
-
-export function SearchBar({ value, onChange }: SearchBarProps) {
+export function SearchBar({ onSubmit }: { onSubmit: (query: string) => void }) {
+  const { onChange, query } = useSearch();
   return (
-    <div className="flex gap-2 mb-5">
-      <input
-        type="text"
-        value={value}
-        onChange={(e) => onChange(e)}
-        placeholder="사건명으로 검색 (예: 한국 2002년 월드컵)"
-        className="flex-1 h-10 px-4 text-sm border border-gray-200 rounded-lg bg-gray-50 text-gray-900 placeholder:text-gray-400 outline-none focus:border-gray-400 focus:bg-white transition-colors"
-      />
-      <button
-        type="submit"
-        className="h-10 px-5 text-sm font-medium border border-gray-200 rounded-lg text-gray-700 hover:bg-gray-50 transition-colors whitespace-nowrap"
-      >
-        검색
-      </button>
-    </div>
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit(query);
+      }}
+    >
+      <div className="flex gap-2 mb-5">
+        <input
+          type="text"
+          value={query}
+          onChange={onChange}
+          placeholder="사건명으로 검색 (예: 한국 2002년 월드컵)"
+          className="flex-1 h-10 px-4 text-sm border border-gray-200 rounded-lg bg-gray-50 text-gray-900 placeholder:text-gray-400 outline-none focus:border-gray-400 focus:bg-white transition-colors"
+        />
+        <button
+          type="submit"
+          className="h-10 px-5 text-sm font-medium border border-gray-200 rounded-lg text-gray-700 hover:bg-gray-50 transition-colors whitespace-nowrap"
+        >
+          검색
+        </button>
+      </div>
+    </form>
   );
 }

--- a/src/shared/provider/getQueryClient.tsx
+++ b/src/shared/provider/getQueryClient.tsx
@@ -1,9 +1,4 @@
-// getQueryClient.ts
-import {
-  isServer,
-  QueryClient,
-  defaultShouldDehydrateQuery,
-} from '@tanstack/react-query';
+import { isServer, QueryClient } from '@tanstack/react-query';
 
 const DEFAULT_STALE_TIME = 60 * 1000;
 
@@ -11,7 +6,6 @@ function makeQueryClient() {
   return new QueryClient({
     defaultOptions: {
       queries: {
-        // staleTime을 60초로 잡아서 즉시 refetch 방지
         staleTime: DEFAULT_STALE_TIME,
       },
     },


### PR DESCRIPTION
### 제목 : 뉴스 플랫폼 형식 오류 수정

### 🖇️ 관련 이슈

- #20 

### 🔎 작업 내용

- 언론사명 추출 기능 추가
- input 입력 시 페이지 내 다른 컴포넌트 리렌더링 오류 수정
- 도메인 fallback 구조 보완
- 불필요한 주석 제거 및 타입 명시

### ➕ 추가 설명
언론사명 추출 구조
SOURCE_MAP 정적 딕셔너리만으로는 미등록 언론사의 URL이 그대로 노출되는 문제가 있었습니다. 이를 3단계 fallback 구조로 개선

1. SOURCE_MAP — 등록된 주요 언론사 우선 반환
2. og:site_name 파싱 — /api/site-name Route에서 HTML을 fetch해 언론사가 직접 명시한 이름 추출. 단, 구분자(-, |) 포함 시 기사 제목이 혼입된 것으로 판단해 제외
3. 도메인 추출 fallback — tldts의 domainWithoutSuffix로 서브도메인·접미사를 제거한 핵심 도메인만 반환 (news.tvchosun.com → tvchosun)

EUC-KR 인코딩 언론사 대응을 위해 response.text() 대신 arrayBuffer() + TextDecoder로 인코딩을 감지 후 디코딩

**리렌더링 버그 수정**
getSourceName이 async 함수임에도 렌더 함수 내에서 직접 호출되어 매 렌더마다 /api/site-name이 반복 호출되는 버그 존재
ArticleItem을 별도 컴포넌트로 분리하고 useSourceName 훅에서 useEffect로 url 변경 시에만 호출되도록 수정

<br/>
close #20